### PR TITLE
Reward service: delete reward data when course is deleted#17

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/reward/controller/SubscriptionController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/reward/controller/SubscriptionController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.gits.reward.controller;
 
+import de.unistuttgart.iste.gits.common.event.CourseChangeEvent;
 import de.unistuttgart.iste.gits.common.event.UserProgressLogEvent;
 import de.unistuttgart.iste.gits.generated.dto.RewardScores;
 import de.unistuttgart.iste.gits.reward.service.*;
@@ -38,5 +39,19 @@ public class SubscriptionController {
                 return null;
             }
         });
+    }
+
+    @Topic(name = "course-changes", pubsubName = "gits")
+    @PostMapping(path = "/reward-service/course-changes-pubsub")
+    public Mono<Void> updateAssociation(@RequestBody CloudEvent<CourseChangeEvent> cloudEvent, @RequestHeader Map<String, String> headers){
+
+        return Mono.fromRunnable(
+                () -> {
+                    try {
+                        rewardService.removeRewardData(cloudEvent.getData());
+                    } catch (NullPointerException e) {
+                        log.error(e.getMessage());
+                    }
+                });
     }
 }

--- a/src/test/java/de/unistuttgart/iste/gits/reward/service/RewardServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/reward/service/RewardServiceTest.java
@@ -1,5 +1,7 @@
 package de.unistuttgart.iste.gits.reward.service;
 
+import de.unistuttgart.iste.gits.common.event.CourseChangeEvent;
+import de.unistuttgart.iste.gits.common.event.CrudOperation;
 import de.unistuttgart.iste.gits.common.event.UserProgressLogEvent;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.reward.persistence.dao.AllRewardScoresEntity;
@@ -200,6 +202,37 @@ class RewardServiceTest {
         verify(allRewardScoresRepository, times(1)).findAllRewardScoresEntitiesById_CourseId(courseId);
 
 
+    }
+
+    @Test
+    void testDataDeletion() {
+        // arrange test data
+        UUID courseId = UUID.randomUUID();
+
+        UUID userId1 = UUID.randomUUID();
+        UUID userId2 = UUID.randomUUID();
+        UUID userId3 = UUID.randomUUID();
+
+        AllRewardScoresEntity rewardScores1 = dummyAllRewardScoresBuilder(courseId, userId1).power(initializeRewardScoreEntity(10)).build();
+        AllRewardScoresEntity rewardScores2 = dummyAllRewardScoresBuilder(courseId, userId2).power(initializeRewardScoreEntity(30)).build();
+        AllRewardScoresEntity rewardScores3 = dummyAllRewardScoresBuilder(courseId, userId3).build();
+
+        List<AllRewardScoresEntity> rewardScoresEntities = new ArrayList<>();
+        rewardScoresEntities.add(rewardScores1);
+        rewardScoresEntities.add(rewardScores2);
+        rewardScoresEntities.add(rewardScores3);
+
+        CourseChangeEvent event = CourseChangeEvent.builder().courseId(courseId).operation(CrudOperation.DELETE).build();
+
+        // mock repository
+        when(allRewardScoresRepository.findAllRewardScoresEntitiesById_CourseId(courseId)).thenReturn(rewardScoresEntities);
+
+        // act
+        rewardService.removeRewardData(event);
+
+
+        // verify that the repository was called
+        verify(allRewardScoresRepository, times(1)).findAllRewardScoresEntitiesById_CourseId(courseId);
     }
 
     private static AllRewardScoresEntity.AllRewardScoresEntityBuilder dummyAllRewardScoresBuilder(UUID courseId, UUID userId) {

--- a/src/test/java/de/unistuttgart/iste/gits/reward/service/RewardServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/reward/service/RewardServiceTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class RewardServiceTest {
@@ -244,6 +245,33 @@ class RewardServiceTest {
                 .growth(initializeRewardScoreEntity(0))
                 .power(initializeRewardScoreEntity(0));
 
+    }
+
+    @Test
+    void testInvalidCourseEventInput(){
+        CourseChangeEvent noCourseIdEvent = CourseChangeEvent.builder().operation(CrudOperation.DELETE).build();
+        CourseChangeEvent noOperationEvent = CourseChangeEvent.builder().courseId(UUID.randomUUID()).build();
+
+
+        // act
+        assertThrows(NullPointerException.class, () -> rewardService.removeRewardData(noCourseIdEvent));
+        assertThrows(NullPointerException.class, () -> rewardService.removeRewardData(noOperationEvent));
+
+        // verify that the repository was called
+        verify(allRewardScoresRepository, never()).findAllRewardScoresEntitiesById_CourseId(any());
+
+    }
+
+    @Test
+    void testWrongOperationTypeCourseEventInput(){
+        CourseChangeEvent createEvent = CourseChangeEvent.builder().courseId(UUID.randomUUID()).operation(CrudOperation.CREATE).build();
+        CourseChangeEvent updateEvent = CourseChangeEvent.builder().courseId(UUID.randomUUID()).operation(CrudOperation.UPDATE).build();
+
+        rewardService.removeRewardData(createEvent);
+        rewardService.removeRewardData(updateEvent);
+
+        // verify that the repository was called
+        verify(allRewardScoresRepository, never()).findAllRewardScoresEntitiesById_CourseId(any());
     }
 
     private static RewardScoreEntity initializeRewardScoreEntity(int initialValue) {


### PR DESCRIPTION
## Description of changes
- Added Subscription Controller method for Course-Change-Events
- Added deletion of reward data when a course is deleted
- Added unit test to test new function

Closes #17 
Can be merged immediatly after approval

## How has this been tested?

- [X] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

    
## Checklist before requesting a review

- [X] My code is easy to understand
- [X] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [X] My code fulfills all acceptance criteria
- [X] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [X] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [X] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
